### PR TITLE
fix: add omitzero to requestObj.ID so notifications omit id on wire

### DIFF
--- a/request.go
+++ b/request.go
@@ -8,7 +8,7 @@ import (
 // requestObj is the JSON-serializable form of a JSON-RPC 2.0 request object.
 type requestObj struct {
 	JSONRPC string          `json:"jsonrpc"`
-	ID      any             `json:"id"`
+	ID      any             `json:"id,omitzero"`
 	Method  string          `json:"method"`
 	Params  json.RawMessage `json:"params,omitzero"`
 }


### PR DESCRIPTION
## Summary

- Adds `omitzero` to the `ID` field tag in `requestObj` (`request.go:11`)
- JSON-RPC 2.0 §4 requires notifications to have **no** `id` member; previously a nil ID serialized as `"id":null`, which spec-compliant servers may treat as a request with a null id rather than a notification

Fixes #1

https://claude.ai/code/session_019S4iZTs54MMhmZSDeS5mh7