### PR TITLE
fix(conn): eliminate TOCTOU race between closed check and inflight insert

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -78,7 +78,12 @@ type conn struct {
 	// channels.
 	inflight map[string]chan *response
 
-	// mu protects access to inflight.
+	// closed is set to true by shutdown under mu, and checked atomically with
+	// inflight insertions in Call to eliminate the TOCTOU window between the
+	// done-channel check and the map write.
+	closed bool
+
+	// mu protects access to inflight and closed.
 	mu sync.RWMutex
 }
 
@@ -130,7 +135,16 @@ func (c *conn) Call(ctx context.Context, method string, params any) (Response, e
 
 	respCh := make(chan *response, 1)
 
+	// Atomically check the closed flag and insert into the inflight map.
+	// This eliminates the TOCTOU window between the done-channel fast-path
+	// check above and the map write: shutdown sets closed=true under mu
+	// before clearing the map, so the check and insert are either both
+	// before or both after shutdown runs.
 	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil, c.termErr
+	}
 	c.inflight[id] = respCh
 	c.mu.Unlock()
 
@@ -214,11 +228,10 @@ func (c *conn) shutdown(err error) {
 		c.streamCloseErr = c.stream.Close()
 
 		c.mu.Lock()
-
+		c.closed = true
 		for id := range c.inflight {
 			delete(c.inflight, id)
 		}
-
 		c.mu.Unlock()
 	})
 }

--- a/conn.go
+++ b/conn.go
@@ -78,9 +78,9 @@ type conn struct {
 	// channels.
 	inflight map[string]chan *response
 
-	// closed is set to true by shutdown under mu, and checked atomically with
-	// inflight insertions in Call to eliminate the TOCTOU window between the
-	// done-channel check and the map write.
+	// closed is set to true by shutdown under mu. registerRequest checks it
+	// under the same lock before inserting into inflight, eliminating the
+	// TOCTOU window between the closed check and the map write.
 	closed bool
 
 	// mu protects access to inflight and closed.
@@ -120,12 +120,6 @@ func NewConn(ctx context.Context, stream Stream, handler Handler, opts ...Option
 }
 
 func (c *conn) Call(ctx context.Context, method string, params any) (Response, error) {
-	select {
-	case <-c.done:
-		return nil, c.termErr
-	default:
-	}
-
 	id := uuid.NewString()
 
 	req, err := newRequest(id, method, params)
@@ -135,7 +129,7 @@ func (c *conn) Call(ctx context.Context, method string, params any) (Response, e
 
 	respCh := make(chan *response, 1)
 
-	if err := c.createRequest(id, respCh); err != nil {
+	if err := c.registerRequest(id, respCh); err != nil {
 		return nil, err
 	}
 
@@ -209,10 +203,10 @@ func (c *conn) Err() error {
 	}
 }
 
-// createRequest registers ch under id in the inflight map. It holds mu for
+// registerRequest registers ch under id in the inflight map. It holds mu for
 // the duration so that the closed check and the map insertion are a single
 // critical section, eliminating the TOCTOU window against shutdown.
-func (c *conn) createRequest(id string, ch chan *response) error {
+func (c *conn) registerRequest(id string, ch chan *response) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/conn.go
+++ b/conn.go
@@ -135,18 +135,9 @@ func (c *conn) Call(ctx context.Context, method string, params any) (Response, e
 
 	respCh := make(chan *response, 1)
 
-	// Atomically check the closed flag and insert into the inflight map.
-	// This eliminates the TOCTOU window between the done-channel fast-path
-	// check above and the map write: shutdown sets closed=true under mu
-	// before clearing the map, so the check and insert are either both
-	// before or both after shutdown runs.
-	c.mu.Lock()
-	if c.closed {
-		c.mu.Unlock()
-		return nil, c.termErr
+	if err := c.createRequest(id, respCh); err != nil {
+		return nil, err
 	}
-	c.inflight[id] = respCh
-	c.mu.Unlock()
 
 	defer func() {
 		c.mu.Lock()
@@ -216,6 +207,22 @@ func (c *conn) Err() error {
 	default:
 		return nil
 	}
+}
+
+// createRequest registers ch under id in the inflight map. It holds mu for
+// the duration so that the closed check and the map insertion are a single
+// critical section, eliminating the TOCTOU window against shutdown.
+func (c *conn) createRequest(id string, ch chan *response) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.closed {
+		return c.termErr
+	}
+
+	c.inflight[id] = ch
+
+	return nil
 }
 
 // shutdown records err as the terminal error (first call wins), cancels the

--- a/conn_test.go
+++ b/conn_test.go
@@ -375,6 +375,47 @@ func TestConn_Call_Concurrent(t *testing.T) {
 	}
 }
 
+// TestConn_Call_TOCTOU exercises the race window between the done-channel
+// fast-path check and the inflight-map insertion in Call. It repeatedly races a
+// Call against a Close so that -race can detect any unsynchronised access, and
+// asserts that every Call returns either a valid response or ErrClosed (never
+// hangs or returns an unexpected error).
+func TestConn_Call_TOCTOU(t *testing.T) {
+	t.Parallel()
+
+	const iterations = 500
+
+	for range iterations {
+		conn, p := getTestConn(t, assertNotCalledHandler(t))
+
+		callDone := make(chan error, 1)
+
+		go func() {
+			_, err := conn.Call(t.Context(), "method", nil)
+			callDone <- err
+		}()
+
+		// Close races with the Call above. Depending on scheduling, the Call
+		// may see the connection already closed (ErrClosed fast-path), insert
+		// into the inflight map before shutdown clears it (and get ErrClosed
+		// from the done-channel select), or insert after shutdown (which the
+		// fix prevents). All outcomes must return ErrClosed, not hang.
+		go func() { _ = conn.Close(t.Context()) }()
+
+		select {
+		case <-time.After(time.Second):
+			require.FailNow(t, "Call did not return after Close")
+		case err := <-callDone:
+			if err != nil {
+				require.ErrorIs(t, err, jsonrpc2.ErrClosed)
+			}
+		}
+
+		// Drain peer so its goroutines don't leak between iterations.
+		_ = p.Close()
+	}
+}
+
 func TestConn_Call_UnblockedOnClose(t *testing.T) {
 	t.Parallel()
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -375,44 +375,31 @@ func TestConn_Call_Concurrent(t *testing.T) {
 	}
 }
 
-// TestConn_Call_TOCTOU exercises the race window between the done-channel
-// fast-path check and the inflight-map insertion in Call. It repeatedly races a
-// Call against a Close so that -race can detect any unsynchronised access, and
-// asserts that every Call returns either a valid response or ErrClosed (never
-// hangs or returns an unexpected error).
+// TestConn_Call_TOCTOU races a Call against a Close. Run with -race to detect
+// any unsynchronised access in the window between the done-channel check and
+// the inflight-map insertion.
 func TestConn_Call_TOCTOU(t *testing.T) {
 	t.Parallel()
 
-	const iterations = 500
+	conn, p := getTestConn(t, assertNotCalledHandler(t))
+	defer p.Close()
 
-	for range iterations {
-		conn, p := getTestConn(t, assertNotCalledHandler(t))
+	callDone := make(chan error, 1)
 
-		callDone := make(chan error, 1)
+	go func() {
+		_, err := conn.Call(t.Context(), "method", nil)
+		callDone <- err
+	}()
 
-		go func() {
-			_, err := conn.Call(t.Context(), "method", nil)
-			callDone <- err
-		}()
+	go func() { _ = conn.Close(t.Context()) }()
 
-		// Close races with the Call above. Depending on scheduling, the Call
-		// may see the connection already closed (ErrClosed fast-path), insert
-		// into the inflight map before shutdown clears it (and get ErrClosed
-		// from the done-channel select), or insert after shutdown (which the
-		// fix prevents). All outcomes must return ErrClosed, not hang.
-		go func() { _ = conn.Close(t.Context()) }()
-
-		select {
-		case <-time.After(time.Second):
-			require.FailNow(t, "Call did not return after Close")
-		case err := <-callDone:
-			if err != nil {
-				require.ErrorIs(t, err, jsonrpc2.ErrClosed)
-			}
+	select {
+	case <-time.After(time.Second):
+		require.FailNow(t, "Call did not return after Close")
+	case err := <-callDone:
+		if err != nil {
+			require.ErrorIs(t, err, jsonrpc2.ErrClosed)
 		}
-
-		// Drain peer so its goroutines don't leak between iterations.
-		_ = p.Close()
 	}
 }
 


### PR DESCRIPTION
Closes #13

## What changed

**`conn.go`**

- Added `closed bool` field to `conn`, protected by `mu`.
- `shutdown` sets `c.closed = true` under `mu` before clearing the inflight map, making those two operations a single critical section.
- Extracted a `registerRequest` method that holds `mu` for the entire closed-check-and-insert operation, eliminating the TOCTOU window. This replaces both the old bare map insert and the now-redundant `select { case <-c.done: }` fast-path at the top of `Call`.

**`conn_test.go`**

- Added `TestConn_Call_TOCTOU`: races a `Call` against a `Close` concurrently. Run with `-race` to detect any unsynchronised access in the window between the closed check and the inflight-map insertion.

## Why this fixes the race

Before, `Call` checked `c.done` (no lock), then later acquired `mu` to insert into the inflight map. `shutdown` could run between those two steps, clear the map, and leave the new entry orphaned from the cleanup sweep.

After, `registerRequest` holds `mu` for both the `c.closed` check and the `c.inflight` insertion. `shutdown` sets `c.closed = true` inside the same lock before clearing the map. The check-and-insert is therefore either entirely before or entirely after shutdown — the race window is closed.