### PR TITLE
Fix race between handleResponse and Call's deferred delete on inflight map

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -382,9 +382,15 @@ func (c *conn) handleResponse(ctx context.Context, resp *response) {
 		return
 	}
 
-	c.mu.RLock()
+	// Delete under the write lock so only one goroutine can claim the channel.
+	// A duplicate response arriving concurrently will find the entry already
+	// gone and return without sending. Call's deferred delete becomes a no-op.
+	c.mu.Lock()
 	ch, ok := c.inflight[id]
-	c.mu.RUnlock()
+	if ok {
+		delete(c.inflight, id)
+	}
+	c.mu.Unlock()
 
 	if ok {
 		select {

--- a/conn.go
+++ b/conn.go
@@ -84,7 +84,7 @@ type conn struct {
 	closed bool
 
 	// mu protects access to inflight and closed.
-	mu sync.RWMutex
+	mu sync.Mutex
 }
 
 var _ Conn = (*conn)(nil)
@@ -111,7 +111,7 @@ func NewConn(ctx context.Context, stream Stream, handler Handler, opts ...Option
 		streamCloseErr: nil,
 		wg:             sync.WaitGroup{},
 		inflight:       make(map[string]chan *response),
-		mu:             sync.RWMutex{},
+		mu:             sync.Mutex{},
 	}
 
 	go c.run(ctx)

--- a/conn.go
+++ b/conn.go
@@ -387,9 +387,7 @@ func (c *conn) handleResponse(ctx context.Context, resp *response) {
 	// gone and return without sending. Call's deferred delete becomes a no-op.
 	c.mu.Lock()
 	ch, ok := c.inflight[id]
-	if ok {
-		delete(c.inflight, id)
-	}
+	delete(c.inflight, id)
 	c.mu.Unlock()
 
 	if ok {


### PR DESCRIPTION
Promote the RLock in handleResponse to a write lock and delete the entry
atomically with the lookup. This ensures only one goroutine can ever claim
a response channel, closing the window where a duplicate response could be
enqueued on an abandoned channel after Call had already returned.

Fixes #16

https://claude.ai/code/session_01BQBMFWSMwuaDjkTwGZKBUp