### PR TITLE
Guard Replier against double-reply (fixes #15)

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	"github.com/google/uuid"
 )
@@ -368,12 +369,19 @@ func (c *conn) handleResponse(ctx context.Context, resp *response) {
 
 // replier returns a [Replier] bound to the request ID.
 // Notifications (id == nil) return a no-op.
+// The returned Replier returns [ErrReplied] on any call after the first.
 func (c *conn) replier(id any) Replier {
 	if id == nil {
 		return func(context.Context, any) error { return nil }
 	}
 
+	var replied atomic.Bool
+
 	return func(ctx context.Context, result any) error {
+		if replied.Swap(true) {
+			return ErrReplied
+		}
+
 		var resp *response
 
 		if jerr, ok := result.(Error); ok {

--- a/conn_test.go
+++ b/conn_test.go
@@ -432,3 +432,41 @@ func TestConn_Call_UnblockedOnClose(t *testing.T) {
 		require.ErrorIs(t, err, jsonrpc2.ErrClosed)
 	}
 }
+
+func TestConn_Replier_DoubleReply(t *testing.T) {
+	t.Parallel()
+
+	repliedCh := make(chan error, 2)
+
+	handler := jsonrpc2.HandlerFunc(func(ctx context.Context, _ jsonrpc2.Request, reply jsonrpc2.Replier, _ jsonrpc2.Conn) error {
+		repliedCh <- reply(ctx, "first")
+		repliedCh <- reply(ctx, "second")
+		return nil
+	})
+
+	conn, p := getTestConn(t, handler)
+	defer conn.Close(t.Context())
+
+	// Send a request from the peer side.
+	req := []byte(`{"jsonrpc":"2.0","id":"test-1","method":"test","params":null}`)
+	_, err := p.Write(req)
+	require.NoError(t, err)
+
+	// Drain the one real response so the write loop doesn't stall.
+	var resp json.RawMessage
+	require.NoError(t, json.NewDecoder(p).Decode(&resp))
+
+	select {
+	case <-t.Context().Done():
+		require.FailNow(t, "handler did not complete")
+	case err := <-repliedCh:
+		assert.NoError(t, err, "first reply should succeed")
+	}
+
+	select {
+	case <-t.Context().Done():
+		require.FailNow(t, "handler did not complete")
+	case err := <-repliedCh:
+		require.ErrorIs(t, err, jsonrpc2.ErrReplied, "second reply should return ErrReplied")
+	}
+}

--- a/error.go
+++ b/error.go
@@ -9,6 +9,9 @@ import (
 var (
 	// ErrClosed is returned by method calls of a closed [Conn].
 	ErrClosed = errors.New("connection closed")
+
+	// ErrReplied is returned by a [Replier] that has already been called once.
+	ErrReplied = errors.New("reply already sent")
 )
 
 // ErrorCode is an error code. Standard codes are in the range [-32768, -32000];


### PR DESCRIPTION
Add ErrReplied sentinel and an atomic.Bool flag in replier() so that
any call to a Replier after the first returns ErrReplied instead of
silently enqueuing a second response for the same request ID.

https://claude.ai/code/session_01UDyFzaenrfnEtxqgy74WkL