### PR TITLE
test: strengthen TestConn_Notify error assertions (fix #5)

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -141,7 +141,7 @@ func TestConn_Notify(t *testing.T) {
 		cancel()
 
 		err := conn.Notify(ctx, "", nil)
-		assert.Error(t, err)
+		require.ErrorIs(t, err, context.Canceled)
 	})
 
 	t.Run("closed conn", func(t *testing.T) {
@@ -152,7 +152,7 @@ func TestConn_Notify(t *testing.T) {
 		require.NoError(t, conn.Close(t.Context()))
 
 		err := conn.Notify(t.Context(), "", nil)
-		assert.Error(t, err)
+		require.ErrorIs(t, err, jsonrpc2.ErrClosed)
 	})
 
 	t.Run("ok", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes #5
- Replaces `assert.Error(t, err)` with `require.ErrorIs(t, err, context.Canceled)` in the `"canceled context"` subtest
- Replaces `assert.Error(t, err)` with `require.ErrorIs(t, err, jsonrpc2.ErrClosed)` in the `"closed conn"` subtest

These now match the stronger assertions used in the equivalent `TestConn_Call` subtests.

## Test plan

- [x] `go test ./... -run TestConn_Notify` passes with all subtests green

https://claude.ai/code/session_011pqS2hxJdkLTJfn9oz7QbE