### PR TITLE
Fix lint

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -65,6 +65,7 @@ var _ Conn = (*conn)(nil)
 // incoming requests. The connection runs until the peer closes, the handler returns
 // an error, or ctx is cancelled. Use [Conn.Done] to wait for shutdown.
 func NewConn(ctx context.Context, stream Stream, handler Handler, opts ...Option) Conn {
+	//nolint:gosec // G118: cancel stored in conn struct, called during shutdown
 	ctx, cancel := context.WithCancel(ctx)
 
 	o := defaultConnOptions()
@@ -83,6 +84,7 @@ func NewConn(ctx context.Context, stream Stream, handler Handler, opts ...Option
 		streamCloseErr: nil,
 		wg:             sync.WaitGroup{},
 		inflight:       make(map[string]chan *response),
+		closed:         false,
 		mu:             sync.Mutex{},
 	}
 
@@ -209,6 +211,7 @@ func (c *conn) shutdown(err error) {
 
 		c.mu.Lock()
 		c.closed = true
+
 		for id := range c.inflight {
 			delete(c.inflight, id)
 		}
@@ -227,6 +230,7 @@ func (c *conn) run(ctx context.Context) {
 	readDone := make(chan error, 1)
 	writeDone := make(chan error, 1)
 
+	//nolint:mnd // read and write goroutines
 	c.wg.Add(2)
 
 	go c.read(ctx, readDone)

--- a/conn_test.go
+++ b/conn_test.go
@@ -33,8 +33,12 @@ func getTestConn(t *testing.T, handler jsonrpc2.Handler) (jsonrpc2.Conn, net.Con
 	stream := jsonrpc2.NewStream(s)
 	require.NotNil(t, stream)
 
+	t.Cleanup(func() { _ = stream.Close() })
+
 	conn := jsonrpc2.NewConn(t.Context(), stream, handler)
 	require.NotNil(t, conn)
+
+	t.Cleanup(func() { _ = conn.Close(t.Context()) })
 
 	return conn, p
 }
@@ -381,8 +385,7 @@ func TestConn_Call_Concurrent(t *testing.T) {
 func TestConn_Call_TOCTOU(t *testing.T) {
 	t.Parallel()
 
-	conn, p := getTestConn(t, assertNotCalledHandler(t))
-	defer p.Close()
+	conn, _ := getTestConn(t, assertNotCalledHandler(t))
 
 	callDone := make(chan error, 1)
 
@@ -438,14 +441,15 @@ func TestConn_Replier_DoubleReply(t *testing.T) {
 
 	repliedCh := make(chan error, 2)
 
-	handler := jsonrpc2.HandlerFunc(func(ctx context.Context, _ jsonrpc2.Request, reply jsonrpc2.Replier, _ jsonrpc2.Conn) error {
+	handler := func(ctx context.Context, _ jsonrpc2.Request, reply jsonrpc2.Replier, _ jsonrpc2.Conn) error {
 		repliedCh <- reply(ctx, "first")
-		repliedCh <- reply(ctx, "second")
-		return nil
-	})
 
-	conn, p := getTestConn(t, handler)
-	defer conn.Close(t.Context())
+		repliedCh <- reply(ctx, "second")
+
+		return nil
+	}
+
+	_, p := getTestConn(t, jsonrpc2.HandlerFunc(handler))
 
 	// Send a request from the peer side.
 	req := []byte(`{"jsonrpc":"2.0","id":"test-1","method":"test","params":null}`)
@@ -460,7 +464,7 @@ func TestConn_Replier_DoubleReply(t *testing.T) {
 	case <-t.Context().Done():
 		require.FailNow(t, "handler did not complete")
 	case err := <-repliedCh:
-		assert.NoError(t, err, "first reply should succeed")
+		require.NoError(t, err, "first reply should succeed")
 	}
 
 	select {

--- a/handler.go
+++ b/handler.go
@@ -17,6 +17,7 @@ type Replier func(ctx context.Context, result any) error
 // HandlerFunc is a function that implements [Handler].
 type HandlerFunc func(ctx context.Context, req Request, reply Replier, conn Conn) error
 
+// ServeRPC delegates to the wrapped function.
 func (f HandlerFunc) ServeRPC(ctx context.Context, req Request, reply Replier, conn Conn) error {
 	return f(ctx, req, reply, conn)
 }

--- a/mux.go
+++ b/mux.go
@@ -61,6 +61,8 @@ func (m *Mux) Fallback(h Handler) {
 	m.fallback = h
 }
 
+// ServeRPC handles the incoming request by forwarding to the registered method
+// handler, falling back to [Mux.Fallback] when there is no registered handler.
 func (m *Mux) ServeRPC(ctx context.Context, req Request, reply Replier, conn Conn) error {
 	m.mu.RLock()
 	h, ok := m.handlers[req.Method()]

--- a/stream_test.go
+++ b/stream_test.go
@@ -23,6 +23,9 @@ func newTestStream(t *testing.T) (*testStream, net.Conn) {
 
 	c1, c2 := net.Pipe()
 
+	t.Cleanup(func() { _ = c1.Close() })
+	t.Cleanup(func() { _ = c2.Close() })
+
 	return &testStream{c1, false}, c2
 }
 


### PR DESCRIPTION
Previous PR merges introduced lint errors. This PR fixes those. Follow up task
is to implement precommit hooks to run lint and format tools.