### PR TITLE
docs(mux): document and test hang when HandleNotification receives a request

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -136,8 +136,7 @@ func Handle[P, R any](m *Mux, method string, f func(ctx context.Context, params 
 // Unmarshal errors and [Error] returns are silently discarded.
 //
 // If the peer sends a regular request (non-nil ID) to this method, no reply is
-// ever sent. The remote peer will hang waiting for a response that never
-// arrives, until its own timeout or connection close.
+// ever sent. The remote peer will never receive a response.
 func HandleNotification[P any](
 	m *Mux, method string, f func(ctx context.Context, params Nullable[P], conn Conn) error,
 ) {

--- a/mux.go
+++ b/mux.go
@@ -136,8 +136,8 @@ func Handle[P, R any](m *Mux, method string, f func(ctx context.Context, params 
 // Unmarshal errors and [Error] returns are silently discarded.
 //
 // If the peer sends a regular request (non-nil ID) to this method, no reply is
-// ever sent. The caller will block on [Conn.Call] until its context is
-// cancelled or the connection closes.
+// ever sent. The remote peer will hang waiting for a response that never
+// arrives, until its own timeout or connection close.
 func HandleNotification[P any](
 	m *Mux, method string, f func(ctx context.Context, params Nullable[P], conn Conn) error,
 ) {

--- a/mux.go
+++ b/mux.go
@@ -134,6 +134,10 @@ func Handle[P, R any](m *Mux, method string, f func(ctx context.Context, params 
 
 // HandleNotification registers a typed notification handler for method on m.
 // Unmarshal errors and [Error] returns are silently discarded.
+//
+// If the peer sends a regular request (non-nil ID) to this method, no reply is
+// ever sent. The caller will block on [Conn.Call] until its context is
+// cancelled or the connection closes.
 func HandleNotification[P any](
 	m *Mux, method string, f func(ctx context.Context, params Nullable[P], conn Conn) error,
 ) {

--- a/mux_test.go
+++ b/mux_test.go
@@ -147,6 +147,34 @@ func TestMux_ServeRPC_Fallback_Error(t *testing.T) {
 	assert.ErrorContains(t, err, "fallback handler:")
 }
 
+// TestHandleNotification_RegularRequest_NoReply documents that a method
+// registered with HandleNotification never calls the Replier, even when the
+// peer sends a regular request (non-nil ID). On a live connection the caller
+// blocks on Conn.Call until its context is cancelled or the connection closes.
+func TestHandleNotification_RegularRequest_NoReply(t *testing.T) {
+	t.Parallel()
+
+	mux := jsonrpc2.NewMux()
+	replierCalled := false
+
+	jsonrpc2.HandleNotification(mux, "notify",
+		func(_ context.Context, _ jsonrpc2.Nullable[struct{}], _ jsonrpc2.Conn) error {
+			return nil
+		},
+	)
+
+	reply := jsonrpc2.Replier(func(_ context.Context, _ any) error {
+		replierCalled = true
+
+		return nil
+	})
+
+	req := &stubRequest{id: "1", method: "notify", params: nil}
+	err := mux.ServeRPC(t.Context(), req, reply, nil)
+	require.NoError(t, err)
+	assert.False(t, replierCalled, "HandleNotification must not reply to a non-nil-ID request; the caller hangs until context cancel or connection close")
+}
+
 func TestMux_Fallback_Replace(t *testing.T) {
 	t.Parallel()
 

--- a/mux_test.go
+++ b/mux_test.go
@@ -149,8 +149,8 @@ func TestMux_ServeRPC_Fallback_Error(t *testing.T) {
 
 // TestHandleNotification_RegularRequest_NoReply documents that a method
 // registered with HandleNotification never calls the Replier, even when the
-// peer sends a regular request (non-nil ID). On a live connection the caller
-// blocks on Conn.Call until its context is cancelled or the connection closes.
+// peer sends a regular request (non-nil ID). The remote peer will hang waiting
+// for a response that never arrives, until its own timeout or connection close.
 func TestHandleNotification_RegularRequest_NoReply(t *testing.T) {
 	t.Parallel()
 
@@ -173,7 +173,7 @@ func TestHandleNotification_RegularRequest_NoReply(t *testing.T) {
 	err := mux.ServeRPC(t.Context(), req, reply, nil)
 	require.NoError(t, err)
 	assert.False(t, replierCalled,
-		"HandleNotification discards the Replier; caller hangs on Conn.Call until ctx cancel or conn close")
+		"HandleNotification discards the Replier; the remote peer hangs waiting for a response that never arrives")
 }
 
 func TestMux_Fallback_Replace(t *testing.T) {

--- a/mux_test.go
+++ b/mux_test.go
@@ -149,8 +149,8 @@ func TestMux_ServeRPC_Fallback_Error(t *testing.T) {
 
 // TestHandleNotification_RegularRequest_NoReply documents that a method
 // registered with HandleNotification never calls the Replier, even when the
-// peer sends a regular request (non-nil ID). The remote peer will hang waiting
-// for a response that never arrives, until its own timeout or connection close.
+// peer sends a regular request (non-nil ID). The remote peer will never
+// receive a response.
 func TestHandleNotification_RegularRequest_NoReply(t *testing.T) {
 	t.Parallel()
 
@@ -173,7 +173,7 @@ func TestHandleNotification_RegularRequest_NoReply(t *testing.T) {
 	err := mux.ServeRPC(t.Context(), req, reply, nil)
 	require.NoError(t, err)
 	assert.False(t, replierCalled,
-		"HandleNotification discards the Replier; the remote peer hangs waiting for a response that never arrives")
+		"HandleNotification discards the Replier; the remote peer will never receive a response")
 }
 
 func TestMux_Fallback_Replace(t *testing.T) {

--- a/mux_test.go
+++ b/mux_test.go
@@ -172,7 +172,8 @@ func TestHandleNotification_RegularRequest_NoReply(t *testing.T) {
 	req := &stubRequest{id: "1", method: "notify", params: nil}
 	err := mux.ServeRPC(t.Context(), req, reply, nil)
 	require.NoError(t, err)
-	assert.False(t, replierCalled, "HandleNotification must not reply to a non-nil-ID request; the caller hangs until context cancel or connection close")
+	assert.False(t, replierCalled,
+		"HandleNotification discards the Replier; caller hangs on Conn.Call until ctx cancel or conn close")
 }
 
 func TestMux_Fallback_Replace(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds a doc-comment to `HandleNotification` explaining that a peer sending a regular request (non-nil ID) to a notification-only method will block on `Conn.Call` indefinitely, since the `Replier` is always discarded.
- Adds `TestHandleNotification_RegularRequest_NoReply` to assert the replier is never invoked in that scenario, documenting the hang behavior with a failing assertion as the guard.

Closes #6

https://claude.ai/code/session_015yJhrnZCTT1rv8YWZCH6DV