### PR TITLE
Clean up README and add example_test.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ go get github.com/mcriley821/jsonrpc2
 | `Handler` | Processes incoming requests. Use `Mux` + `Handle`/`HandleNotification` for typed, per-method dispatch. |
 | `Error`   | A JSON-RPC error object. `NewError` creates one; return it from a handler to send an error response.   |
 
-Standard JSON-RPC 2.0 error codes are exported as constants: `ParseError` (−32700), `InvalidRequest` (−32600), `MethodNotFound` (−32601), `InvalidParams` (−32602), `InternalError` (−32603). Application-defined codes should be outside the range −32768 to −32000.
-
 ## Examples
 
 See [`example_test.go`](./example_test.go) for runnable examples covering the full server-client flow, typed handlers, nullable params, error responses, raw handler registration, and connection lifecycle.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ go get github.com/mcriley821/jsonrpc2
 
 ## Overview
 
-The library is organized around four concepts:
-
 | Concept   | Description                                                                                            |
 |-----------|--------------------------------------------------------------------------------------------------------|
 | `Stream`  | Wraps an `io.ReadWriteCloser` with JSON encoding/decoding.                                             |
@@ -22,161 +20,12 @@ The library is organized around four concepts:
 | `Handler` | Processes incoming requests. Use `Mux` + `Handle`/`HandleNotification` for typed, per-method dispatch. |
 | `Error`   | A JSON-RPC error object. `NewError` creates one; return it from a handler to send an error response.   |
 
-## Quick start
+Standard JSON-RPC 2.0 error codes are exported as constants: `ParseError` (−32700), `InvalidRequest` (−32600), `MethodNotFound` (−32601), `InvalidParams` (−32602), `InternalError` (−32603). Application-defined codes should be outside the range −32768 to −32000.
 
-### Server
+## Examples
 
-```go
-mux := jsonrpc2.NewMux()
+See [`example_test.go`](./example_test.go) for runnable examples covering the full server-client flow, typed handlers, nullable params, error responses, raw handler registration, and connection lifecycle.
 
-// Typed request handler — params unmarshaled, result marshaled automatically.
-jsonrpc2.Handle(mux, "add", func(ctx context.Context, p jsonrpc2.Nullable[AddParams], conn jsonrpc2.Conn) (AddResult, error) {
-    return AddResult{Sum: p.Value.A + p.Value.B}, nil
-})
+## AI-Assisted Development
 
-// Typed notification handler — no response is sent.
-jsonrpc2.HandleNotification(mux, "log", func(ctx context.Context, p jsonrpc2.Nullable[LogParams], conn jsonrpc2.Conn) error {
-    slog.Info(p.Value.Message)
-    return nil
-})
-
-ln, _ := net.Listen("tcp", ":8080")
-for {
-    nc, _ := ln.Accept()
-    stream := jsonrpc2.NewStream(nc)
-    conn := jsonrpc2.NewConn(ctx, stream, jsonrpc2.WithHandler(mux))
-    go func() { <-conn.Done() }() // wait for shutdown
-}
-```
-
-### Client
-
-```go
-nc, _ := net.Dial("tcp", "localhost:8080")
-stream := jsonrpc2.NewStream(nc)
-// No WithHandler needed for client-only use — unexpected requests get MethodNotFound.
-conn := jsonrpc2.NewConn(ctx, stream)
-defer conn.Close(ctx)
-
-resp, err := conn.Call(ctx, "add", AddParams{A: 1, B: 2})
-if err != nil {
-    log.Fatal(err)
-}
-
-if resp.Failed() {
-    log.Fatalf("rpc error %d: %s", resp.Error().Code(), resp.Error().Message())
-}
-
-var result AddResult
-if err := resp.Result(&result); err != nil {
-    log.Fatal(err)
-}
-fmt.Println(result.Sum) // 3
-```
-
-## Typed handler registration
-
-`Handle` and `HandleNotification` are package-level generic functions that wrap a strongly-typed function into a `Handler` and register it on a `Mux`.
-
-```go
-func Handle[P, R any](m *Mux, method string, f func(ctx context.Context, params Nullable[P], conn Conn) (R, error))
-func HandleNotification[P any](m *Mux, method string, f func(ctx context.Context, params Nullable[P], conn Conn) error)
-```
-
-### Params decoding
-
-- When params are present, `req.Params()` is decoded into `P` via `json.Unmarshal` and the handler receives `Nullable[P]{Value: p, Valid: true}`.
-- When params are absent (omitted entirely), the handler receives `Nullable[P]{Valid: false}` — no unmarshal is attempted.
-- Malformed params produce an `InvalidParams` error response (for requests) or are silently discarded (for notifications, per §6 of the spec).
-
-```go
-// Nullable params — check Valid to distinguish absent params from present ones.
-jsonrpc2.Handle(mux, "optional", func(ctx context.Context, p jsonrpc2.Nullable[MyParams], conn jsonrpc2.Conn) (MyResult, error) {
-    if !p.Valid {
-        return defaultResult(), nil
-    }
-    return process(p.Value), nil
-})
-```
-
-### Error handling
-
-Return a `*rpcError` (created with `NewError`) to send a JSON-RPC error response. Any other non-nil error closes the connection.
-
-```go
-jsonrpc2.Handle(mux, "divide", func(ctx context.Context, p jsonrpc2.Nullable[DivParams], conn jsonrpc2.Conn) (DivResult, error) {
-    if p.Value.B == 0 {
-        return DivResult{}, jsonrpc2.NewError(jsonrpc2.InvalidParams, "division by zero", nil)
-    }
-    return DivResult{Quotient: p.Value.A / p.Value.B}, nil
-})
-```
-
-For notification handlers (`HandleNotification`), `Error` returns are silently discarded; only non-RPC errors propagate.
-
-## Mux
-
-`Mux` implements `Handler` and routes incoming requests by method name.
-
-```go
-mux := jsonrpc2.NewMux()
-
-// Register a raw handler.
-mux.Handle("raw", jsonrpc2.HandlerFunc(func(ctx context.Context, req jsonrpc2.Request, reply jsonrpc2.Replier, conn jsonrpc2.Conn) error {
-    return reply(ctx, "ok")
-}))
-
-// Set a catch-all fallback (default: MethodNotFound).
-mux.Fallback(jsonrpc2.HandlerFunc(func(ctx context.Context, req jsonrpc2.Request, reply jsonrpc2.Replier, conn jsonrpc2.Conn) error {
-    return reply(ctx, jsonrpc2.NewError(jsonrpc2.MethodNotFound, req.Method(), nil))
-}))
-```
-
-Registering the same method name twice panics.
-
-## Error codes
-
-Standard JSON-RPC 2.0 error codes are provided as constants:
-
-| Constant         | Code   | Description                |
-|------------------|--------|----------------------------|
-| `ParseError`     | -32700 | Invalid JSON received      |
-| `InvalidRequest` | -32600 | Not a valid Request object |
-| `MethodNotFound` | -32601 | Method does not exist      |
-| `InvalidParams`  | -32602 | Invalid method parameters  |
-| `InternalError`  | -32603 | Internal server error      |
-
-Application-defined codes should be outside the range -32768 to -32000 (reserved by the spec).
-
-## Connection lifecycle
-
-`NewConn` starts background goroutines for reading, writing, and error coordination. The connection shuts down when:
-
-- `conn.Close(ctx)` is called explicitly.
-- The underlying stream fails (read or write error).
-- The parent context is cancelled.
-
-`conn.Done()` returns a channel that is closed when the connection has fully shut down and all background goroutines have exited. It is safe for multiple goroutines to wait on it. `conn.Err()` returns the terminal error after `Done` closes.
-
-```go
-conn := jsonrpc2.NewConn(ctx, stream, jsonrpc2.WithHandler(mux))
-
-go func() {
-    <-conn.Done()
-    if err := conn.Err(); err != nil && !errors.Is(err, jsonrpc2.ErrClosed) {
-        log.Printf("connection error: %v", err)
-    }
-}()
-```
-
-## Sending outbound requests from a handler
-
-The `conn Conn` parameter passed to every handler can be used to make outbound calls or send notifications back to the peer from within the handler:
-
-```go
-jsonrpc2.Handle(mux, "subscribe", func(ctx context.Context, p jsonrpc2.Nullable[SubParams], conn jsonrpc2.Conn) (SubResult, error) {
-    // Send a notification to the peer without waiting for a response.
-    _ = conn.Notify(ctx, "event", EventParams{Type: "subscribed"})
-    return SubResult{OK: true}, nil
-})
-```
+This project is developed with AI assistance — not vibe coded. All generated code is reviewed, understood, and tested before being accepted.

--- a/example_test.go
+++ b/example_test.go
@@ -68,15 +68,15 @@ func ExampleNewMux() {
 	sc, cc := net.Pipe()
 	server := jsonrpc2.NewConn(ctx, jsonrpc2.NewStream(sc), jsonrpc2.WithHandler(mux))
 	client := jsonrpc2.NewConn(ctx, jsonrpc2.NewStream(cc))
-	defer func() {
-		_ = client.Close(ctx)
-		_ = server.Close(ctx)
-	}()
 
 	resp, err := client.Call(ctx, "add", addParams{A: 1, B: 2})
+	_ = client.Close(ctx)
+	_ = server.Close(ctx)
+
 	if err != nil {
 		log.Fatal(err)
 	}
+
 	if resp.Failed() {
 		log.Fatalf("rpc error: %s", resp.Error().Message())
 	}
@@ -85,6 +85,7 @@ func ExampleNewMux() {
 	if err := resp.Result(&result); err != nil {
 		log.Fatal(err)
 	}
+
 	fmt.Println(result.Sum)
 
 	// Output:
@@ -102,6 +103,7 @@ func ExampleHandle_rpcError() {
 			if p.Value.B == 0 {
 				return divResult{}, jsonrpc2.NewError(jsonrpc2.InvalidParams, "division by zero", nil)
 			}
+
 			return divResult{Quotient: p.Value.A / p.Value.B}, nil
 		},
 	)
@@ -109,15 +111,15 @@ func ExampleHandle_rpcError() {
 	sc, cc := net.Pipe()
 	server := jsonrpc2.NewConn(ctx, jsonrpc2.NewStream(sc), jsonrpc2.WithHandler(mux))
 	client := jsonrpc2.NewConn(ctx, jsonrpc2.NewStream(cc))
-	defer func() {
-		_ = client.Close(ctx)
-		_ = server.Close(ctx)
-	}()
 
 	resp, err := client.Call(ctx, "divide", divParams{A: 10, B: 0})
+	_ = client.Close(ctx)
+	_ = server.Close(ctx)
+
 	if err != nil {
 		log.Fatal(err)
 	}
+
 	if resp.Failed() {
 		fmt.Printf("error %d: %s\n", resp.Error().Code(), resp.Error().Message())
 	}
@@ -135,10 +137,13 @@ func ExampleHandle_nullable() {
 			if !p.Valid {
 				return greetResult{Greeting: "hello, world"}, nil
 			}
+
 			return greetResult{Greeting: "hello, " + p.Value.Name}, nil
 		},
 	)
 	_ = mux
+
+	// Output:
 }
 
 // ExampleHandleNotification shows how to register a handler for fire-and-forget
@@ -148,10 +153,13 @@ func ExampleHandleNotification() {
 	jsonrpc2.HandleNotification(mux, "log",
 		func(_ context.Context, p jsonrpc2.Nullable[logParams], _ jsonrpc2.Conn) error {
 			slog.Info(p.Value.Message)
+
 			return nil
 		},
 	)
 	_ = mux
+
+	// Output:
 }
 
 // ExampleMux_Handle shows how to register a raw handler that works directly
@@ -164,6 +172,8 @@ func ExampleMux_Handle() {
 		},
 	))
 	_ = mux
+
+	// Output:
 }
 
 // ExampleMux_Fallback shows how to replace the default MethodNotFound response
@@ -176,6 +186,8 @@ func ExampleMux_Fallback() {
 		},
 	))
 	_ = mux
+
+	// Output:
 }
 
 // ExampleConn_Done shows how to wait for a connection to finish shutting down
@@ -188,16 +200,22 @@ func ExampleConn_Done() {
 	conn := jsonrpc2.NewConn(ctx, jsonrpc2.NewStream(sc))
 
 	shutdown := make(chan struct{})
+
 	go func() {
 		defer close(shutdown)
+
 		<-conn.Done()
+
 		if err := conn.Err(); err != nil && !errors.Is(err, jsonrpc2.ErrClosed) {
 			log.Printf("connection error: %v", err)
 		}
 	}()
 
 	_ = conn.Close(ctx)
+
 	<-shutdown
+
+	// Output:
 }
 
 // ExampleConn_Notify shows how a handler can push a notification back to the
@@ -207,8 +225,11 @@ func ExampleConn_Notify() {
 	jsonrpc2.Handle(mux, "subscribe",
 		func(ctx context.Context, _ jsonrpc2.Nullable[subscribeParams], conn jsonrpc2.Conn) (subscribeResult, error) {
 			_ = conn.Notify(ctx, "event", eventParams{Type: "subscribed"})
+
 			return subscribeResult{OK: true}, nil
 		},
 	)
 	_ = mux
+
+	// Output:
 }

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,214 @@
+package jsonrpc2_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"log/slog"
+	"net"
+
+	"github.com/mcriley821/jsonrpc2"
+)
+
+type addParams struct {
+	A int `json:"a"`
+	B int `json:"b"`
+}
+
+type addResult struct {
+	Sum int `json:"sum"`
+}
+
+type divParams struct {
+	A int `json:"a"`
+	B int `json:"b"`
+}
+
+type divResult struct {
+	Quotient int `json:"quotient"`
+}
+
+type greetParams struct {
+	Name string `json:"name"`
+}
+
+type greetResult struct {
+	Greeting string `json:"greeting"`
+}
+
+type logParams struct {
+	Message string `json:"message"`
+}
+
+type subscribeParams struct {
+	Topic string `json:"topic"`
+}
+
+type subscribeResult struct {
+	OK bool `json:"ok"`
+}
+
+type eventParams struct {
+	Type string `json:"type"`
+}
+
+// ExampleNewMux shows the full server-client flow: register a typed handler,
+// wire up connections over an in-process pipe, and call the method.
+func ExampleNewMux() {
+	ctx := context.Background()
+
+	mux := jsonrpc2.NewMux()
+	jsonrpc2.Handle(mux, "add",
+		func(_ context.Context, p jsonrpc2.Nullable[addParams], _ jsonrpc2.Conn) (addResult, error) {
+			return addResult{Sum: p.Value.A + p.Value.B}, nil
+		},
+	)
+
+	sc, cc := net.Pipe()
+	server := jsonrpc2.NewConn(ctx, jsonrpc2.NewStream(sc), jsonrpc2.WithHandler(mux))
+	client := jsonrpc2.NewConn(ctx, jsonrpc2.NewStream(cc))
+	defer func() {
+		_ = client.Close(ctx)
+		_ = server.Close(ctx)
+	}()
+
+	resp, err := client.Call(ctx, "add", addParams{A: 1, B: 2})
+	if err != nil {
+		log.Fatal(err)
+	}
+	if resp.Failed() {
+		log.Fatalf("rpc error: %s", resp.Error().Message())
+	}
+
+	var result addResult
+	if err := resp.Result(&result); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(result.Sum)
+
+	// Output:
+	// 3
+}
+
+// ExampleHandle_rpcError shows how returning NewError from a handler sends a
+// JSON-RPC error response to the caller.
+func ExampleHandle_rpcError() {
+	ctx := context.Background()
+
+	mux := jsonrpc2.NewMux()
+	jsonrpc2.Handle(mux, "divide",
+		func(_ context.Context, p jsonrpc2.Nullable[divParams], _ jsonrpc2.Conn) (divResult, error) {
+			if p.Value.B == 0 {
+				return divResult{}, jsonrpc2.NewError(jsonrpc2.InvalidParams, "division by zero", nil)
+			}
+			return divResult{Quotient: p.Value.A / p.Value.B}, nil
+		},
+	)
+
+	sc, cc := net.Pipe()
+	server := jsonrpc2.NewConn(ctx, jsonrpc2.NewStream(sc), jsonrpc2.WithHandler(mux))
+	client := jsonrpc2.NewConn(ctx, jsonrpc2.NewStream(cc))
+	defer func() {
+		_ = client.Close(ctx)
+		_ = server.Close(ctx)
+	}()
+
+	resp, err := client.Call(ctx, "divide", divParams{A: 10, B: 0})
+	if err != nil {
+		log.Fatal(err)
+	}
+	if resp.Failed() {
+		fmt.Printf("error %d: %s\n", resp.Error().Code(), resp.Error().Message())
+	}
+
+	// Output:
+	// error -32602: division by zero
+}
+
+// ExampleHandle_nullable shows how to distinguish absent params (Valid == false)
+// from present ones (Valid == true).
+func ExampleHandle_nullable() {
+	mux := jsonrpc2.NewMux()
+	jsonrpc2.Handle(mux, "greet",
+		func(_ context.Context, p jsonrpc2.Nullable[greetParams], _ jsonrpc2.Conn) (greetResult, error) {
+			if !p.Valid {
+				return greetResult{Greeting: "hello, world"}, nil
+			}
+			return greetResult{Greeting: "hello, " + p.Value.Name}, nil
+		},
+	)
+	_ = mux
+}
+
+// ExampleHandleNotification shows how to register a handler for fire-and-forget
+// notifications; no response is ever sent.
+func ExampleHandleNotification() {
+	mux := jsonrpc2.NewMux()
+	jsonrpc2.HandleNotification(mux, "log",
+		func(_ context.Context, p jsonrpc2.Nullable[logParams], _ jsonrpc2.Conn) error {
+			slog.Info(p.Value.Message)
+			return nil
+		},
+	)
+	_ = mux
+}
+
+// ExampleMux_Handle shows how to register a raw handler that works directly
+// with the Request and Replier instead of typed params and results.
+func ExampleMux_Handle() {
+	mux := jsonrpc2.NewMux()
+	mux.Handle("ping", jsonrpc2.HandlerFunc(
+		func(ctx context.Context, _ jsonrpc2.Request, reply jsonrpc2.Replier, _ jsonrpc2.Conn) error {
+			return reply(ctx, "pong")
+		},
+	))
+	_ = mux
+}
+
+// ExampleMux_Fallback shows how to replace the default MethodNotFound response
+// with a custom catch-all handler.
+func ExampleMux_Fallback() {
+	mux := jsonrpc2.NewMux()
+	mux.Fallback(jsonrpc2.HandlerFunc(
+		func(ctx context.Context, req jsonrpc2.Request, reply jsonrpc2.Replier, _ jsonrpc2.Conn) error {
+			return reply(ctx, jsonrpc2.NewError(jsonrpc2.MethodNotFound, req.Method(), nil))
+		},
+	))
+	_ = mux
+}
+
+// ExampleConn_Done shows how to wait for a connection to finish shutting down
+// and inspect the terminal error.
+func ExampleConn_Done() {
+	ctx := context.Background()
+	sc, cc := net.Pipe()
+	_ = cc
+
+	conn := jsonrpc2.NewConn(ctx, jsonrpc2.NewStream(sc))
+
+	shutdown := make(chan struct{})
+	go func() {
+		defer close(shutdown)
+		<-conn.Done()
+		if err := conn.Err(); err != nil && !errors.Is(err, jsonrpc2.ErrClosed) {
+			log.Printf("connection error: %v", err)
+		}
+	}()
+
+	_ = conn.Close(ctx)
+	<-shutdown
+}
+
+// ExampleConn_Notify shows how a handler can push a notification back to the
+// peer without waiting for a response.
+func ExampleConn_Notify() {
+	mux := jsonrpc2.NewMux()
+	jsonrpc2.Handle(mux, "subscribe",
+		func(ctx context.Context, _ jsonrpc2.Nullable[subscribeParams], conn jsonrpc2.Conn) (subscribeResult, error) {
+			_ = conn.Notify(ctx, "event", eventParams{Type: "subscribed"})
+			return subscribeResult{OK: true}, nil
+		},
+	)
+	_ = mux
+}


### PR DESCRIPTION
Move all README code examples into runnable Go example tests in
example_test.go. Two of those examples (NewMux, Handle_rpcError) are
testable with Output comments. Condense the README to the overview
table, an error-codes one-liner, a pointer to the examples, and a new
AI-Assisted Development section.

https://claude.ai/code/session_012WXfxSqc3BLQ25xLsRyPRb