### PR TITLE
Add WithLogger option for request/response lifecycle tracing

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -44,6 +44,7 @@ type conn struct {
 
 	stream  Stream
 	handler Handler
+	logger  Logger
 
 	outgoing chan any
 	done     chan struct{}
@@ -82,6 +83,7 @@ func NewConn(ctx context.Context, stream Stream, opts ...Option) Conn {
 		cancel:         cancel,
 		stream:         stream,
 		handler:        o.handler,
+		logger:         o.logger,
 		outgoing:       make(chan any),
 		done:           make(chan struct{}),
 		shutdownOnce:   sync.Once{},
@@ -96,6 +98,13 @@ func NewConn(ctx context.Context, stream Stream, opts ...Option) Conn {
 	go c.run(ctx)
 
 	return c
+}
+
+// log emits a Debug log entry if a logger is configured.
+func (c *conn) log(ctx context.Context, msg string, args ...any) {
+	if c.logger != nil {
+		c.logger.DebugContext(ctx, msg, args...)
+	}
 }
 
 // Call sends a request and waits for a response. Pass nil for params to omit the field.
@@ -125,6 +134,7 @@ func (c *conn) Call(ctx context.Context, method string, params any) (Response, e
 	case <-c.done:
 		return nil, c.termErr
 	case c.outgoing <- req:
+		c.log(ctx, "request sent", "method", method, "id", id)
 	}
 
 	select {
@@ -133,6 +143,7 @@ func (c *conn) Call(ctx context.Context, method string, params any) (Response, e
 	case <-c.done:
 		return nil, c.termErr
 	case resp := <-respCh:
+		c.log(ctx, "response received", "id", id, "failed", resp.Failed())
 		return resp, nil
 	}
 }
@@ -156,6 +167,7 @@ func (c *conn) Notify(ctx context.Context, method string, params any) error {
 	case <-c.done:
 		return c.termErr
 	case c.outgoing <- req:
+		c.log(ctx, "notification sent", "method", method)
 		return nil
 	}
 }
@@ -438,6 +450,7 @@ func (c *conn) handleRequests(ctx context.Context, requests []*request, isBatch 
 
 	for _, req := range requests {
 		wg.Go(func() {
+			c.log(ctx, "request received", "method", req.Method(), "id", req.ID())
 			if err := c.handler.ServeRPC(ctx, req, c.replier(req.ID(), sink), c); err != nil {
 				c.shutdown(fmt.Errorf("handler error: %w", err))
 			}
@@ -523,6 +536,8 @@ func (c *conn) replier(id any, sink chan<- any) Replier {
 		} else {
 			resp = newResponse(id, data)
 		}
+
+		c.log(ctx, "response sent", "id", id)
 
 		select {
 		case <-ctx.Done():

--- a/conn.go
+++ b/conn.go
@@ -100,13 +100,6 @@ func NewConn(ctx context.Context, stream Stream, opts ...Option) Conn {
 	return c
 }
 
-// log emits a Debug log entry if a logger is configured.
-func (c *conn) log(ctx context.Context, msg string, args ...any) {
-	if c.logger != nil {
-		c.logger.DebugContext(ctx, msg, args...)
-	}
-}
-
 // Call sends a request and waits for a response. Pass nil for params to omit the field.
 func (c *conn) Call(ctx context.Context, method string, params any) (Response, error) {
 	id := uuid.NewString()
@@ -144,6 +137,7 @@ func (c *conn) Call(ctx context.Context, method string, params any) (Response, e
 		return nil, c.termErr
 	case resp := <-respCh:
 		c.log(ctx, "response received", "id", id, "failed", resp.Failed())
+
 		return resp, nil
 	}
 }
@@ -168,6 +162,7 @@ func (c *conn) Notify(ctx context.Context, method string, params any) error {
 		return c.termErr
 	case c.outgoing <- req:
 		c.log(ctx, "notification sent", "method", method)
+
 		return nil
 	}
 }
@@ -199,6 +194,13 @@ func (c *conn) Err() error {
 		return c.termErr
 	default:
 		return nil
+	}
+}
+
+// log emits a Debug log entry if a logger is configured.
+func (c *conn) log(ctx context.Context, msg string, args ...any) {
+	if c.logger != nil {
+		c.logger.DebugContext(ctx, msg, args...)
 	}
 }
 
@@ -451,6 +453,7 @@ func (c *conn) handleRequests(ctx context.Context, requests []*request, isBatch 
 	for _, req := range requests {
 		wg.Go(func() {
 			c.log(ctx, "request received", "method", req.Method(), "id", req.ID())
+
 			if err := c.handler.ServeRPC(ctx, req, c.replier(req.ID(), sink), c); err != nil {
 				c.shutdown(fmt.Errorf("handler error: %w", err))
 			}

--- a/option.go
+++ b/option.go
@@ -19,6 +19,7 @@ type connOptions struct {
 func defaultConnOptions() connOptions {
 	return connOptions{
 		handler: HandlerFunc(defaultHandler),
+		logger:  nil,
 	}
 }
 

--- a/option.go
+++ b/option.go
@@ -5,8 +5,16 @@ import "context"
 // Option configures a [Conn] created by [NewConn].
 type Option func(*connOptions)
 
+// Logger is the interface accepted by [WithLogger].
+// [*slog.Logger] satisfies this interface automatically.
+type Logger interface {
+	Debug(msg string, args ...any)
+	DebugContext(ctx context.Context, msg string, args ...any)
+}
+
 type connOptions struct {
 	handler Handler
+	logger  Logger
 }
 
 func defaultConnOptions() connOptions {
@@ -27,5 +35,16 @@ func defaultHandler(ctx context.Context, _ Request, reply Replier, _ Conn) error
 func WithHandler(h Handler) Option {
 	return func(o *connOptions) {
 		o.handler = h
+	}
+}
+
+// WithLogger sets the [Logger] used to trace the request/response lifecycle.
+// Log entries are emitted at Debug level for outgoing requests and
+// notifications, incoming requests, outgoing responses, and incoming
+// responses. When no WithLogger option is provided, logging is disabled.
+// [*slog.Logger] satisfies [Logger] without an adapter.
+func WithLogger(l Logger) Option {
+	return func(o *connOptions) {
+		o.logger = l
 	}
 }

--- a/option.go
+++ b/option.go
@@ -8,7 +8,6 @@ type Option func(*connOptions)
 // Logger is the interface accepted by [WithLogger].
 // [*slog.Logger] satisfies this interface automatically.
 type Logger interface {
-	Debug(msg string, args ...any)
 	DebugContext(ctx context.Context, msg string, args ...any)
 }
 

--- a/option_test.go
+++ b/option_test.go
@@ -1,0 +1,146 @@
+package jsonrpc2_test
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mcriley821/jsonrpc2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type spyLogger struct {
+	mu      sync.Mutex
+	entries []string
+}
+
+func (s *spyLogger) Debug(msg string, _ ...any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries = append(s.entries, msg)
+}
+
+func (s *spyLogger) DebugContext(_ context.Context, msg string, _ ...any) {
+	s.Debug(msg)
+}
+
+func (s *spyLogger) messages() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.entries))
+	copy(out, s.entries)
+	return out
+}
+
+func getTestConnLogger(t *testing.T, handler jsonrpc2.Handler, logger jsonrpc2.Logger) (jsonrpc2.Conn, net.Conn) {
+	t.Helper()
+
+	s, p := newTestStream(t)
+	stream := jsonrpc2.NewStream(s)
+	require.NotNil(t, stream)
+	t.Cleanup(func() { _ = stream.Close() })
+
+	conn := jsonrpc2.NewConn(t.Context(), stream,
+		jsonrpc2.WithHandler(handler),
+		jsonrpc2.WithLogger(logger),
+	)
+	require.NotNil(t, conn)
+	t.Cleanup(func() { _ = conn.Close(t.Context()) })
+
+	return conn, p
+}
+
+func TestWithLogger_CallLogsRequestSentAndResponseReceived(t *testing.T) {
+	t.Parallel()
+
+	spy := &spyLogger{}
+	conn, p := getTestConnLogger(t, assertNotCalledHandler(t), spy)
+
+	idCh := make(chan any, 1)
+	errCh := make(chan error, 1)
+	go pipeRespond(t, p, idCh, errCh, nil)
+
+	_, err := conn.Call(t.Context(), "ping", nil)
+	require.NoError(t, err)
+
+	select {
+	case err := <-errCh:
+		require.FailNow(t, err.Error())
+	case <-idCh:
+	}
+
+	msgs := spy.messages()
+	assert.Contains(t, msgs, "request sent")
+	assert.Contains(t, msgs, "response received")
+}
+
+func TestWithLogger_NotifyLogsNotificationSent(t *testing.T) {
+	t.Parallel()
+
+	spy := &spyLogger{}
+	conn, p := getTestConnLogger(t, assertNotCalledHandler(t), spy)
+
+	notifCh := make(chan []byte, 1)
+	errCh := make(chan error, 1)
+	go pipeNotif(t, p, notifCh, errCh)
+
+	err := conn.Notify(t.Context(), "event", nil)
+	require.NoError(t, err)
+
+	select {
+	case err := <-errCh:
+		require.FailNow(t, err.Error())
+	case <-notifCh:
+	}
+
+	assert.Contains(t, spy.messages(), "notification sent")
+}
+
+func TestWithLogger_ServerSideLogsRequestReceivedAndResponseSent(t *testing.T) {
+	t.Parallel()
+
+	handlerDone := make(chan struct{})
+
+	handler := jsonrpc2.HandlerFunc(func(ctx context.Context, _ jsonrpc2.Request, reply jsonrpc2.Replier, _ jsonrpc2.Conn) error {
+		defer close(handlerDone)
+		return reply(ctx, "ok")
+	})
+
+	spy := &spyLogger{}
+	_, p := getTestConnLogger(t, handler, spy)
+
+	_, err := p.Write([]byte(`{"jsonrpc":"2.0","id":"1","method":"doSomething"}`))
+	require.NoError(t, err)
+
+	// drain the response
+	var raw json.RawMessage
+	require.NoError(t, json.NewDecoder(p).Decode(&raw))
+
+	select {
+	case <-time.After(time.Second):
+		require.FailNow(t, "handler did not complete")
+	case <-handlerDone:
+	}
+
+	msgs := spy.messages()
+	assert.Contains(t, msgs, "request received")
+	assert.Contains(t, msgs, "response sent")
+}
+
+func TestWithLogger_NilLogger_NoPanic(t *testing.T) {
+	t.Parallel()
+
+	conn, p := getTestConn(t, assertNotCalledHandler(t))
+
+	idCh := make(chan any, 1)
+	errCh := make(chan error, 1)
+	go pipeRespond(t, p, idCh, errCh, nil)
+
+	assert.NotPanics(t, func() {
+		_, _ = conn.Call(t.Context(), "ping", nil)
+	})
+}

--- a/option_test.go
+++ b/option_test.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/mcriley821/jsonrpc2"
 	"github.com/stretchr/testify/assert"
@@ -18,14 +17,10 @@ type spyLogger struct {
 	entries []string
 }
 
-func (s *spyLogger) Debug(msg string, _ ...any) {
+func (s *spyLogger) DebugContext(_ context.Context, msg string, _ ...any) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.entries = append(s.entries, msg)
-}
-
-func (s *spyLogger) DebugContext(_ context.Context, msg string, _ ...any) {
-	s.Debug(msg)
 }
 
 func (s *spyLogger) messages() []string {
@@ -36,7 +31,7 @@ func (s *spyLogger) messages() []string {
 	return out
 }
 
-func getTestConnLogger(t *testing.T, handler jsonrpc2.Handler, logger jsonrpc2.Logger) (jsonrpc2.Conn, net.Conn) {
+func getTestConnWithLogger(t *testing.T, handler jsonrpc2.Handler, logger jsonrpc2.Logger) (jsonrpc2.Conn, net.Conn) {
 	t.Helper()
 
 	s, p := newTestStream(t)
@@ -58,7 +53,7 @@ func TestWithLogger_CallLogsRequestSentAndResponseReceived(t *testing.T) {
 	t.Parallel()
 
 	spy := &spyLogger{}
-	conn, p := getTestConnLogger(t, assertNotCalledHandler(t), spy)
+	conn, p := getTestConnWithLogger(t, assertNotCalledHandler(t), spy)
 
 	idCh := make(chan any, 1)
 	errCh := make(chan error, 1)
@@ -82,7 +77,7 @@ func TestWithLogger_NotifyLogsNotificationSent(t *testing.T) {
 	t.Parallel()
 
 	spy := &spyLogger{}
-	conn, p := getTestConnLogger(t, assertNotCalledHandler(t), spy)
+	conn, p := getTestConnWithLogger(t, assertNotCalledHandler(t), spy)
 
 	notifCh := make(chan []byte, 1)
 	errCh := make(chan error, 1)
@@ -111,7 +106,7 @@ func TestWithLogger_ServerSideLogsRequestReceivedAndResponseSent(t *testing.T) {
 	})
 
 	spy := &spyLogger{}
-	_, p := getTestConnLogger(t, handler, spy)
+	_, p := getTestConnWithLogger(t, handler, spy)
 
 	_, err := p.Write([]byte(`{"jsonrpc":"2.0","id":"1","method":"doSomething"}`))
 	require.NoError(t, err)
@@ -121,7 +116,7 @@ func TestWithLogger_ServerSideLogsRequestReceivedAndResponseSent(t *testing.T) {
 	require.NoError(t, json.NewDecoder(p).Decode(&raw))
 
 	select {
-	case <-time.After(time.Second):
+	case <-t.Context().Done():
 		require.FailNow(t, "handler did not complete")
 	case <-handlerDone:
 	}

--- a/option_test.go
+++ b/option_test.go
@@ -20,14 +20,17 @@ type spyLogger struct {
 func (s *spyLogger) DebugContext(_ context.Context, msg string, _ ...any) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
 	s.entries = append(s.entries, msg)
 }
 
 func (s *spyLogger) messages() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
 	out := make([]string, len(s.entries))
 	copy(out, s.entries)
+
 	return out
 }
 
@@ -52,10 +55,11 @@ func getTestConnWithLogger(t *testing.T, handler jsonrpc2.Handler, logger jsonrp
 func TestWithLogger_CallLogsRequestSentAndResponseReceived(t *testing.T) {
 	t.Parallel()
 
-	spy := &spyLogger{}
+	spy := &spyLogger{mu: sync.Mutex{}, entries: nil}
 	conn, p := getTestConnWithLogger(t, assertNotCalledHandler(t), spy)
 
 	idCh := make(chan any, 1)
+
 	errCh := make(chan error, 1)
 	go pipeRespond(t, p, idCh, errCh, nil)
 
@@ -76,10 +80,11 @@ func TestWithLogger_CallLogsRequestSentAndResponseReceived(t *testing.T) {
 func TestWithLogger_NotifyLogsNotificationSent(t *testing.T) {
 	t.Parallel()
 
-	spy := &spyLogger{}
+	spy := &spyLogger{mu: sync.Mutex{}, entries: nil}
 	conn, p := getTestConnWithLogger(t, assertNotCalledHandler(t), spy)
 
 	notifCh := make(chan []byte, 1)
+
 	errCh := make(chan error, 1)
 	go pipeNotif(t, p, notifCh, errCh)
 
@@ -100,18 +105,21 @@ func TestWithLogger_ServerSideLogsRequestReceivedAndResponseSent(t *testing.T) {
 
 	handlerDone := make(chan struct{})
 
-	handler := jsonrpc2.HandlerFunc(func(ctx context.Context, _ jsonrpc2.Request, reply jsonrpc2.Replier, _ jsonrpc2.Conn) error {
-		defer close(handlerDone)
-		return reply(ctx, "ok")
-	})
+	handler := jsonrpc2.HandlerFunc(
+		func(ctx context.Context, _ jsonrpc2.Request, reply jsonrpc2.Replier, _ jsonrpc2.Conn) error {
+			defer close(handlerDone)
 
-	spy := &spyLogger{}
+			return reply(ctx, "ok")
+		},
+	)
+
+	spy := &spyLogger{mu: sync.Mutex{}, entries: nil}
+
 	_, p := getTestConnWithLogger(t, handler, spy)
 
 	_, err := p.Write([]byte(`{"jsonrpc":"2.0","id":"1","method":"doSomething"}`))
 	require.NoError(t, err)
 
-	// drain the response
 	var raw json.RawMessage
 	require.NoError(t, json.NewDecoder(p).Decode(&raw))
 
@@ -132,6 +140,7 @@ func TestWithLogger_NilLogger_NoPanic(t *testing.T) {
 	conn, p := getTestConn(t, assertNotCalledHandler(t))
 
 	idCh := make(chan any, 1)
+
 	errCh := make(chan error, 1)
 	go pipeRespond(t, p, idCh, errCh, nil)
 


### PR DESCRIPTION
Implements issue #11. Defines a Logger interface that *slog.Logger
satisfies automatically, adds a WithLogger(Logger) Option, and wires
debug log calls into Conn at five lifecycle points: request sent,
notification sent, request received, response sent, response received.

https://claude.ai/code/session_01BFFhV3HfXxwkdJLAi3ZDhz