### PR TITLE
feat: Add Batch method for outbound JSON-RPC 2.0 batch calls

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -25,6 +25,12 @@ type Conn interface {
 	// Returns an error if the connection is closed, ctx expires, or if marshaling the request fails.
 	Notify(ctx context.Context, method string, params any) error
 
+	// Batch sends multiple request items as a single batch. It returns one Response
+	// per non-notification item, in input order. Returns nil if every item is a
+	// notification. Returns an error if the batch is empty, ctx expires, the
+	// connection is closed, or any item fails to marshal.
+	Batch(ctx context.Context, items ...BatchItem) ([]Response, error)
+
 	// Close gracefully shuts down the connection and waits for shutdown to complete.
 	// Safe to call multiple times. Returns an error if ctx expires before shutdown finishes.
 	Close(ctx context.Context) error
@@ -36,6 +42,32 @@ type Conn interface {
 	// Err returns the terminal error, or nil if the connection is still running.
 	// Check [Conn.Done] first; Err is only valid after [Conn.Done] closes.
 	Err() error
+}
+
+// BatchItem is a single entry in an outbound batch.
+// Construct with [BatchCall] or [BatchNotification].
+type BatchItem struct {
+	method  string
+	params  any
+	isNotif bool
+}
+
+// BatchCall creates a batch item for a request that expects a response.
+func BatchCall(method string, params any) BatchItem {
+	return BatchItem{
+		method:  method,
+		params:  params,
+		isNotif: false,
+	}
+}
+
+// BatchNotification creates a batch item for a notification.
+func BatchNotification(method string, params any) BatchItem {
+	return BatchItem{
+		method:  method,
+		params:  params,
+		isNotif: true,
+	}
 }
 
 // conn is an implementation of [Conn].
@@ -109,9 +141,9 @@ func (c *conn) Call(ctx context.Context, method string, params any) (Response, e
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 
-	respCh := make(chan *response, 1)
+	respMap := map[string]chan *response{id: make(chan *response, 1)}
 
-	if err := c.registerRequests(map[string]chan *response{id: respCh}); err != nil {
+	if err := c.registerRequests(respMap); err != nil {
 		return nil, err
 	}
 
@@ -130,16 +162,48 @@ func (c *conn) Call(ctx context.Context, method string, params any) (Response, e
 		c.log(ctx, "request sent", "method", method, "id", id)
 	}
 
+	_, resp, err := c.receiveResponse(ctx, respMap)
+
+	return resp, err
+}
+
+// Batch sends multiple request items as a single batch and waits for a response, if applicable.
+func (c *conn) Batch(ctx context.Context, items ...BatchItem) ([]Response, error) {
+	if len(items) == 0 {
+		return nil, errors.New("batch is empty")
+	}
+
+	reqs, respChans, idxMap, err := c.buildBatch(items)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		c.mu.Lock()
+
+		for id := range respChans {
+			delete(c.inflight, id)
+		}
+
+		c.mu.Unlock()
+	}()
+
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err() //nolint:wrapcheck
 	case <-c.done:
 		return nil, c.termErr
-	case resp := <-respCh:
-		c.log(ctx, "response received", "id", id, "failed", resp.Failed())
-
-		return resp, nil
+	case c.outgoing <- reqs:
+		c.log(ctx, "batch sent", "items", len(reqs))
 	}
+
+	if len(respChans) == 0 {
+		return nil, nil
+	}
+
+	responses := make([]Response, len(items))
+
+	return responses, c.collectBatchResponses(ctx, responses, idxMap, respChans)
 }
 
 // Notify sends a notification. Pass nil for params to omit the field.
@@ -202,6 +266,75 @@ func (c *conn) log(ctx context.Context, msg string, args ...any) {
 	if c.logger != nil {
 		c.logger.DebugContext(ctx, msg, args...)
 	}
+}
+
+// buildBatch creates the requests, response channels, and index mappings required to properly route responses back to
+// their corresponding requests in a Batch call.
+func (c *conn) buildBatch(items []BatchItem) ([]*request, map[string]chan *response, map[string]int, error) {
+	reqs := make([]*request, len(items))
+	respChans := make(map[string]chan *response)
+	idxMap := make(map[string]int)
+
+	for i, item := range items {
+		var id any
+
+		if !item.isNotif {
+			uid := uuid.NewString()
+			id = uid
+			respCh := make(chan *response, 1)
+			respChans[uid] = respCh
+			idxMap[uid] = i
+		}
+
+		req, err := newRequest(id, item.method, item.params)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("creating request: %w", err)
+		}
+
+		reqs[i] = req
+	}
+
+	return reqs, respChans, idxMap, c.registerRequests(respChans)
+}
+
+// collectBatchResponses fills in the responses array with the corresponding response by index.
+func (c *conn) collectBatchResponses(
+	ctx context.Context,
+	responses []Response,
+	idxMap map[string]int,
+	respChans map[string]chan *response,
+) error {
+	for len(respChans) > 0 {
+		id, resp, err := c.receiveResponse(ctx, respChans)
+		if err != nil {
+			return err
+		}
+
+		responses[idxMap[id]] = resp
+	}
+
+	return nil
+}
+
+// receiveResponse returns a single response and its corresponding request id from the given response channels.
+// note: this function will remove the entry from the map on success.
+func (c *conn) receiveResponse(ctx context.Context, respChans map[string]chan *response) (string, *response, error) {
+	for id, ch := range respChans {
+		select {
+		case <-ctx.Done():
+			return "", nil, ctx.Err() //nolint:wrapcheck
+		case <-c.done:
+			return "", nil, c.termErr
+		case resp := <-ch:
+			c.log(ctx, "response received", "id", id)
+
+			delete(respChans, id)
+
+			return id, resp, nil
+		}
+	}
+
+	return "", nil, errors.New("no response channels available")
 }
 
 // registerRequests registers requests in the inflight map. It holds mu for

--- a/conn_test.go
+++ b/conn_test.go
@@ -1,8 +1,10 @@
 package jsonrpc2_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"math/rand"
 	"net"
 	"sync"
@@ -618,4 +620,345 @@ func TestConn_BatchRequest_Handling(t *testing.T) { //nolint:tparallel,funlen
 
 		assert.Error(t, conn.Err())
 	})
+}
+
+func TestConn_Batch_Errors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty batch returns error", func(t *testing.T) {
+		t.Parallel()
+
+		conn, _ := getTestConn(t, assertNotCalledHandler(t))
+
+		resps, err := conn.Batch(t.Context())
+		require.Error(t, err)
+		assert.Nil(t, resps)
+	})
+
+	t.Run("bad params returns error", func(t *testing.T) {
+		t.Parallel()
+
+		conn, _ := getTestConn(t, assertNotCalledHandler(t))
+
+		resps, err := conn.Batch(t.Context(), jsonrpc2.BatchCall("test", func() {}))
+		require.Error(t, err)
+		assert.Nil(t, resps)
+	})
+
+	t.Run("canceled context returns context.Canceled", func(t *testing.T) {
+		t.Parallel()
+
+		conn, _ := getTestConn(t, assertNotCalledHandler(t))
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		resps, err := conn.Batch(ctx, jsonrpc2.BatchCall("test", nil))
+		require.ErrorIs(t, err, context.Canceled)
+		assert.Nil(t, resps)
+	})
+
+	t.Run("closed conn returns ErrClosed", func(t *testing.T) {
+		t.Parallel()
+
+		conn, _ := getTestConn(t, assertNotCalledHandler(t))
+
+		require.NoError(t, conn.Close(t.Context()))
+
+		resps, err := conn.Batch(t.Context(), jsonrpc2.BatchCall("test", nil))
+		require.ErrorIs(t, err, jsonrpc2.ErrClosed)
+		assert.Nil(t, resps)
+	})
+}
+
+func TestConn_Batch_Notifications(t *testing.T) {
+	t.Parallel()
+
+	conn, p := getTestConn(t, assertNotCalledHandler(t))
+
+	peerErrCh := make(chan error, 1)
+
+	go func() {
+		var raw json.RawMessage
+
+		if err := json.NewDecoder(p).Decode(&raw); err != nil {
+			peerErrCh <- err
+
+			return
+		}
+
+		var batch []map[string]any
+
+		if err := json.Unmarshal(raw, &batch); err != nil {
+			peerErrCh <- err
+
+			return
+		}
+
+		for _, item := range batch {
+			_, hasID := item["id"]
+			if hasID {
+				peerErrCh <- errors.New("expected notification (no id) but found id field")
+
+				return
+			}
+		}
+	}()
+
+	resps, err := conn.Batch(t.Context(),
+		jsonrpc2.BatchNotification("method1", nil),
+		jsonrpc2.BatchNotification("method2", nil),
+	)
+	require.NoError(t, err)
+	assert.Nil(t, resps)
+
+	select {
+	case err := <-peerErrCh:
+		require.FailNow(t, err.Error())
+	default:
+	}
+}
+
+func TestConn_Batch_Mixed(t *testing.T) { //nolint:funlen
+	t.Parallel()
+
+	conn, p := getTestConn(t, assertNotCalledHandler(t))
+
+	peerErrCh := make(chan error, 1)
+
+	go func() {
+		var raw json.RawMessage
+
+		if err := json.NewDecoder(p).Decode(&raw); err != nil {
+			peerErrCh <- err
+
+			return
+		}
+
+		var batch []struct {
+			ID     any             `json:"id"`
+			Params json.RawMessage `json:"params"`
+		}
+
+		if err := json.Unmarshal(raw, &batch); err != nil {
+			peerErrCh <- err
+
+			return
+		}
+
+		responses := make([]map[string]any, 0, len(batch))
+
+		for _, item := range batch {
+			resp := map[string]any{
+				"jsonrpc": "2.0",
+				"id":      item.ID,
+				"result":  item.Params,
+			}
+			responses = append(responses, resp)
+		}
+
+		data, err := json.Marshal(responses)
+		if err != nil {
+			peerErrCh <- err
+
+			return
+		}
+
+		if _, err := p.Write(data); err != nil {
+			peerErrCh <- err
+
+			return
+		}
+	}()
+
+	resps, err := conn.Batch(t.Context(),
+		jsonrpc2.BatchCall("method1", "params1"),
+		jsonrpc2.BatchNotification("method2", nil),
+		jsonrpc2.BatchCall("method3", "params3"),
+	)
+	require.NoError(t, err)
+	require.Len(t, resps, 3)
+
+	select {
+	case err := <-peerErrCh:
+		require.FailNow(t, err.Error())
+
+	default:
+	}
+
+	for i, resp := range resps {
+		if i != 1 {
+			require.NotNil(t, resp, "response %d should not be nil", i)
+			assert.False(t, resp.Failed())
+		} else {
+			assert.Nil(t, resp)
+		}
+	}
+}
+
+func TestConn_Batch_WireFormat(t *testing.T) { //nolint:cyclop,funlen
+	t.Parallel()
+
+	conn, p := getTestConn(t, assertNotCalledHandler(t))
+
+	peerErrCh := make(chan error, 1)
+
+	go func() {
+		var raw json.RawMessage
+
+		if err := json.NewDecoder(p).Decode(&raw); err != nil {
+			peerErrCh <- err
+
+			return
+		}
+
+		trimmed := bytes.TrimLeft(raw, " \t\r\n")
+		if len(trimmed) == 0 || trimmed[0] != '[' {
+			peerErrCh <- errors.New("expected JSON array for batch")
+
+			return
+		}
+
+		var batch []struct {
+			ID any `json:"id"`
+		}
+
+		if err := json.Unmarshal(raw, &batch); err != nil {
+			peerErrCh <- err
+
+			return
+		}
+
+		responses := make([]map[string]any, 0)
+
+		for _, item := range batch {
+			if item.ID != nil {
+				resp := map[string]any{
+					"jsonrpc": "2.0",
+					"id":      item.ID,
+					"result":  nil,
+				}
+				responses = append(responses, resp)
+			}
+		}
+
+		data, err := json.Marshal(responses)
+		if err != nil {
+			peerErrCh <- err
+
+			return
+		}
+
+		if _, err := p.Write(data); err != nil {
+			peerErrCh <- err
+
+			return
+		}
+	}()
+
+	resps, err := conn.Batch(t.Context(),
+		jsonrpc2.BatchCall("method1", nil),
+		jsonrpc2.BatchNotification("method2", nil),
+	)
+	require.NoError(t, err)
+	require.Len(t, resps, 2)
+	assert.Nil(t, resps[1])
+
+	select {
+	case err := <-peerErrCh:
+		require.FailNow(t, err.Error())
+	default:
+	}
+}
+
+func TestConn_Batch_Concurrent(t *testing.T) { //nolint:cyclop,funlen
+	t.Parallel()
+
+	conn, p := getTestConn(t, assertNotCalledHandler(t))
+
+	peerErrCh := make(chan error, 1)
+
+	go func() {
+		dec := json.NewDecoder(p)
+
+		for range 2 {
+			var raw json.RawMessage
+
+			if err := dec.Decode(&raw); err != nil {
+				peerErrCh <- err
+
+				return
+			}
+
+			var batch []struct {
+				ID any `json:"id"`
+			}
+
+			if err := json.Unmarshal(raw, &batch); err != nil {
+				peerErrCh <- err
+
+				return
+			}
+
+			responses := make([]map[string]any, 0, len(batch))
+
+			for _, item := range batch {
+				resp := map[string]any{
+					"jsonrpc": "2.0",
+					"id":      item.ID,
+					"result":  "ok",
+				}
+				responses = append(responses, resp)
+			}
+
+			data, err := json.Marshal(responses)
+			if err != nil {
+				peerErrCh <- err
+
+				return
+			}
+
+			if _, err := p.Write(data); err != nil {
+				peerErrCh <- err
+
+				return
+			}
+		}
+	}()
+
+	resultCh := make(chan error, 2)
+
+	for range 2 {
+		go func() {
+			resps, err := conn.Batch(t.Context(),
+				jsonrpc2.BatchCall("method1", nil),
+				jsonrpc2.BatchCall("method2", nil),
+			)
+			if err != nil {
+				resultCh <- err
+
+				return
+			}
+
+			if len(resps) != 2 {
+				resultCh <- errors.New("expected 2 responses")
+
+				return
+			}
+
+			resultCh <- nil
+		}()
+	}
+
+	for range 2 {
+		if err := <-resultCh; err != nil {
+			require.FailNow(t, err.Error())
+		}
+	}
+
+	select {
+	case err := <-peerErrCh:
+		require.FailNow(t, err.Error())
+	default:
+	}
 }


### PR DESCRIPTION
## Summary

- Adds `Batch(ctx, ...BatchItem) ([]Response, error)` to the `Conn` interface for sending outbound JSON-RPC 2.0 batch requests
- Introduces `BatchItem`, `BatchCall`, and `BatchNotification` helpers for constructing batch entries
- Responses are returned in input order; notification slots are `nil`; all-notification batches return `nil, nil`

## Test plan

- [x] `TestConn_Batch_Errors` — empty batch, bad params, cancelled context, closed conn
- [x] `TestConn_Batch_Notifications` — all-notification batch sends correct wire format with no IDs
- [x] `TestConn_Batch_Mixed` — mixed calls and notifications, responses indexed correctly
- [x] `TestConn_Batch_WireFormat` — verifies the wire payload is a JSON array
- [x] `TestConn_Batch_Concurrent` — two concurrent `Batch` calls interleave correctly

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)