### PR TITLE
fix: eagerly send responses even in blocking handlers

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -574,17 +574,26 @@ func (c *conn) write(ctx context.Context, errChan chan<- error) {
 	}
 }
 
-// handleRequests invokes the handler for the incoming requests.
-// If the handler returns an error, the connection is closed.
+// handleRequests invokes the handler for each incoming request. Each handler runs
+// in its own goroutine tracked by c.wg so it may outlive handleRequests itself.
+// Responses are collected and sent as soon as every handler has replied, without
+// waiting for handlers to return. If a handler returns an error, the connection is closed.
 func (c *conn) handleRequests(ctx context.Context, requests []*request, isBatch bool) {
 	defer c.wg.Done()
 
-	sink := make(chan any, len(requests))
-
-	var wg sync.WaitGroup
+	// Count how many requests will produce a response (non-notifications have a non-nil id).
+	expectedResponses := 0
 
 	for _, req := range requests {
-		wg.Go(func() {
+		if req.ID() != nil {
+			expectedResponses++
+		}
+	}
+
+	sink := make(chan any, expectedResponses)
+
+	for _, req := range requests {
+		c.wg.Go(func() {
 			c.log(ctx, "request received", "method", req.Method(), "id", req.ID())
 
 			if err := c.handler.ServeRPC(ctx, req, c.replier(req.ID(), sink), c); err != nil {
@@ -593,14 +602,7 @@ func (c *conn) handleRequests(ctx context.Context, requests []*request, isBatch 
 		})
 	}
 
-	wg.Wait()
-	close(sink)
-
-	out := make([]any, 0, len(requests))
-	for resp := range sink {
-		out = append(out, resp)
-	}
-
+	out := c.collectReplies(ctx, expectedResponses, sink)
 	if len(out) == 0 {
 		return
 	}
@@ -613,9 +615,28 @@ func (c *conn) handleRequests(ctx context.Context, requests []*request, isBatch 
 	}
 
 	select {
-	case <-c.Done():
+	case <-ctx.Done():
 	case c.outgoing <- msg:
 	}
+}
+
+// collectReplies waits for count reply values to arrive on sink, returning them
+// in arrival order. Returns nil immediately if ctx is cancelled. Selecting on
+// ctx.Done() (not c.done) allows a handler that calls shutdown — which cancels
+// ctx — to unblock this function before c.done is closed.
+func (c *conn) collectReplies(ctx context.Context, count int, sink <-chan any) []any {
+	out := make([]any, 0, count)
+
+	for range count {
+		select {
+		case <-ctx.Done():
+			return nil
+		case resp := <-sink:
+			out = append(out, resp)
+		}
+	}
+
+	return out
 }
 
 // handleResponses routes an incoming responses to the waiting [Conn.Call]

--- a/conn_test.go
+++ b/conn_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/rand"
 	"net"
 	"sync"
@@ -556,6 +557,47 @@ func TestNewConn_DefaultHandler_NotificationIgnored(t *testing.T) {
 	assert.Error(t, err, "expected no response for notification with no handler")
 }
 
+func TestNewConn_CallsWithinHandler(t *testing.T) {
+	t.Parallel()
+
+	done := make(chan struct{}, 1)
+
+	_, p := getTestConn(t, jsonrpc2.HandlerFunc(func(
+		ctx context.Context,
+		req jsonrpc2.Request,
+		_ jsonrpc2.Replier,
+		conn jsonrpc2.Conn,
+	) error {
+		assert.Equal(t, "test", req.Method())
+
+		resp, err := conn.Call(ctx, "reply", nil)
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.False(t, resp.Failed())
+
+		done <- struct{}{}
+
+		return nil
+	}))
+
+	_, err := p.Write([]byte(`{"jsonrpc":"2.0","id":"test-id","method":"test"}`))
+	require.NoError(t, err)
+
+	var resp map[string]string
+	require.NoError(t, json.NewDecoder(p).Decode(&resp))
+	require.Contains(t, resp, "id")
+
+	_, err = p.Write(fmt.Appendf(nil, `{"jsonrpc":"2.0","id":"%s","result":null}`, resp["id"]))
+	require.NoError(t, err)
+
+	select {
+	case <-t.Context().Done():
+		require.FailNow(t, "timeout waiting for handler to finish")
+	case <-done:
+	}
+}
+
 func TestConn_Replier_DoubleReply(t *testing.T) {
 	t.Parallel()
 
@@ -677,6 +719,119 @@ func TestConn_BatchRequest_Handling(t *testing.T) { //nolint:funlen
 
 		assert.Error(t, conn.Err())
 	})
+}
+
+// TestConn_ResponseSentBeforeHandlerReturns verifies that a response is sent
+// to the peer as soon as the handler calls the [Replier], even if the handler
+// itself continues to block afterwards.
+func TestConn_ResponseSentBeforeHandlerReturns(t *testing.T) {
+	t.Parallel()
+
+	handlerReplied := make(chan struct{})
+	unblockHandler := make(chan struct{})
+
+	handler := jsonrpc2.HandlerFunc(func(
+		ctx context.Context,
+		_ jsonrpc2.Request,
+		reply jsonrpc2.Replier,
+		_ jsonrpc2.Conn,
+	) error {
+		if err := reply(ctx, "done"); err != nil {
+			return err
+		}
+
+		close(handlerReplied)
+
+		select {
+		case <-unblockHandler:
+		case <-ctx.Done():
+		}
+
+		return nil
+	})
+
+	_, p := getTestConn(t, handler)
+
+	_, err := p.Write([]byte(`{"jsonrpc":"2.0","id":"test-1","method":"test"}`))
+	require.NoError(t, err)
+
+	respCh := make(chan json.RawMessage, 1)
+	peerErrCh := make(chan error, 1)
+
+	go func() {
+		var resp json.RawMessage
+		if err := json.NewDecoder(p).Decode(&resp); err != nil {
+			peerErrCh <- err
+
+			return
+		}
+
+		respCh <- resp
+	}()
+
+	select {
+	case <-t.Context().Done():
+		require.FailNow(t, "handler did not call reply")
+	case <-handlerReplied:
+	}
+
+	// The response must arrive at the peer while the handler is still blocked.
+	select {
+	case <-t.Context().Done():
+		require.FailNow(t, "response not received while handler was blocked after replying")
+	case err := <-peerErrCh:
+		require.NoError(t, err)
+	case resp := <-respCh:
+		assert.NotEmpty(t, resp)
+	}
+
+	close(unblockHandler)
+}
+
+func TestNewConn_BatchResponseDeferredUntilAllHandlersDone(t *testing.T) {
+	t.Parallel()
+
+	_, p := getTestConn(t, jsonrpc2.HandlerFunc(func(
+		ctx context.Context,
+		req jsonrpc2.Request,
+		reply jsonrpc2.Replier,
+		conn jsonrpc2.Conn,
+	) error {
+		switch req.Method() {
+		case "blocking":
+			resp, err := conn.Call(ctx, "inner", nil)
+			require.NoError(t, err)
+			require.False(t, resp.Failed())
+
+			return reply(ctx, "blocking-done")
+		case "immediate":
+			return reply(ctx, "immediate-done")
+		}
+
+		return nil
+	}))
+
+	batch := `[{"jsonrpc":"2.0","id":"b1","method":"blocking"},{"jsonrpc":"2.0","id":"b2","method":"immediate"}]`
+	_, err := p.Write([]byte(batch))
+	require.NoError(t, err)
+
+	// The "inner" call from the blocking handler arrives first because the
+	// batch response is held until both handlers have replied.
+	// Reading the batch response before responding here would deadlock.
+	var innerCall map[string]any
+	require.NoError(t, json.NewDecoder(p).Decode(&innerCall))
+	require.Equal(t, "inner", innerCall["method"])
+
+	innerID, ok := innerCall["id"].(string)
+	require.True(t, ok)
+
+	_, err = p.Write(fmt.Appendf(nil, `{"jsonrpc":"2.0","id":"%s","result":null}`, innerID))
+	require.NoError(t, err)
+
+	// Now both handlers can finish, and the batch response arrives.
+	var batchResp []map[string]any
+	require.NoError(t, json.NewDecoder(p).Decode(&batchResp))
+	require.Len(t, batchResp, 2)
 }
 
 func TestConn_Batch_Errors(t *testing.T) {


### PR DESCRIPTION
In handleRequests, wg.Wait() blocks until every handler goroutine returns before draining sink and sending responses. If a handler calls reply() and then blocks, the response sits in sink but never gets forwarded until the handler exits.

This PR fixes that issue by launching handler goroutines on the conn waitgroup and drains the sink when all the expected replies have been received. 