### PR TITLE
feat(conn): recover handler panics and reply with InternalError (#41)

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -594,9 +594,25 @@ func (c *conn) handleRequests(ctx context.Context, requests []*request, isBatch 
 
 	for _, req := range requests {
 		c.wg.Go(func() {
+			reply := c.replier(req.ID(), sink)
+
+			// Recover handler panics so a single misbehaving handler can't tear
+			// down the whole connection. For requests we report InternalError;
+			// notifications are silently dropped (no response is expected and
+			// the replier is a no-op anyway).
+			defer func() {
+				if r := recover(); r != nil {
+					c.log(ctx, "handler panic recovered",
+						"method", req.Method(), "id", req.ID(), "panic", r)
+					if req.ID() != nil {
+						_ = reply(ctx, NewError(InternalError, "internal server error", nil))
+					}
+				}
+			}()
+
 			c.log(ctx, "request received", "method", req.Method(), "id", req.ID())
 
-			if err := c.handler.ServeRPC(ctx, req, c.replier(req.ID(), sink), c); err != nil {
+			if err := c.handler.ServeRPC(ctx, req, reply, c); err != nil {
 				c.shutdown(fmt.Errorf("handler error: %w", err))
 			}
 		})

--- a/conn_test.go
+++ b/conn_test.go
@@ -598,6 +598,57 @@ func TestNewConn_CallsWithinHandler(t *testing.T) {
 	}
 }
 
+func TestConn_HandlerPanic_RequestRepliesInternalError(t *testing.T) {
+	t.Parallel()
+
+	handler := func(_ context.Context, _ jsonrpc2.Request, _ jsonrpc2.Replier, _ jsonrpc2.Conn) error {
+		panic("boom")
+	}
+
+	conn, p := getTestConn(t, jsonrpc2.HandlerFunc(handler))
+
+	_, err := p.Write([]byte(`{"jsonrpc":"2.0","id":"panic-1","method":"test","params":null}`))
+	require.NoError(t, err)
+
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(p).Decode(&resp))
+
+	assert.Equal(t, "panic-1", resp["id"])
+	require.Contains(t, resp, "error")
+
+	errObj, ok := resp["error"].(map[string]any)
+	require.True(t, ok, "expected error object")
+	assert.Equal(t, float64(jsonrpc2.InternalError), errObj["code"])
+
+	// Connection should still be alive after the panic.
+	select {
+	case <-conn.Done():
+		require.FailNow(t, "connection should remain open after handler panic")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestConn_HandlerPanic_NotificationDropped(t *testing.T) {
+	t.Parallel()
+
+	handler := func(_ context.Context, _ jsonrpc2.Request, _ jsonrpc2.Replier, _ jsonrpc2.Conn) error {
+		panic("boom")
+	}
+
+	conn, p := getTestConn(t, jsonrpc2.HandlerFunc(handler))
+
+	_, err := p.Write([]byte(`{"jsonrpc":"2.0","method":"test","params":null}`))
+	require.NoError(t, err)
+
+	// No response is expected for a notification; ensure the connection
+	// stays open and a follow-up request still gets processed.
+	select {
+	case <-conn.Done():
+		require.FailNow(t, "connection should remain open after notification panic")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
 func TestConn_Replier_DoubleReply(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Closes #41. A panicking handler currently propagates up through the per-request goroutine in ``conn.handleRequests``, killing the goroutine and tearing down the connection ungracefully. The peer receives no response and no error, the connection just closes.

This change recovers the panic inside the per-request goroutine and:

- For **requests** (non-nil ID): replies with ``NewError(InternalError, \"internal server error\", nil)``. The replier's ``atomic.Bool`` guard means this is harmless if the handler had already replied before panicking.
- For **notifications** (nil ID): drops silently, no response is expected and the replier is a no-op for notifications anyway.
- The recovered panic value is logged via the configured ``Logger`` so operators can still find it in the logs.

The wire-side error message is the generic ``\"internal server error\"`` (panic value not leaked to peer); the actual ``%v`` of the panic goes to the structured log.

## Why this matches the issue

- ✅ Recovers in the per-request goroutine in ``handleRequests``
- ✅ Replies with InternalError for requests, drops for notifications
- ✅ Logs the recovered panic value
- ✅ Connection stays open

## Test plan

- [x] ``go build ./...``, clean
- [x] ``go test ./...``, full suite passes
- [x] New ``TestConn_HandlerPanic_RequestRepliesInternalError``, verifies a panicking handler produces an ``InternalError`` reply with the correct code and the connection stays alive
- [x] New ``TestConn_HandlerPanic_NotificationDropped``, verifies a panicking notification handler is silently absorbed and the connection stays alive